### PR TITLE
Clean up upstream localStorage leak

### DIFF
--- a/src/oauth-facade.ts
+++ b/src/oauth-facade.ts
@@ -101,6 +101,15 @@ export default class OauthFacade {
     // Fetch a valid auth response (or throw)
     const authRequestResponse = await this.authHandler.resolveAuthorizationRequest();
 
+    // We have discovered in practice that @openid/appauth fails to properly clean up its
+    // storage entries in some cases. We add this hack to manually garbage collect all
+    // outstanding storage entries that the upstream library has left behind. Note that this
+    // depends on implementation details of both this class (namely the use of LocalStorageBackend)
+    // as well as of @openid/appauth (namely its storage key name conventions).
+    Object.keys(localStorage).filter((key) => key.includes('appauth_authorization')).forEach((key) => {
+      localStorage.removeItem(key);
+    });
+
     // Exchange for an access token and return tokenResponse
     const tokenRequest = new TokenRequest({
       client_id: this.clientId,

--- a/src/oauth-facade.ts
+++ b/src/oauth-facade.ts
@@ -106,6 +106,8 @@ export default class OauthFacade {
     // outstanding storage entries that the upstream library has left behind. Note that this
     // depends on implementation details of both this class (namely the use of LocalStorageBackend)
     // as well as of @openid/appauth (namely its storage key name conventions).
+    // The relevant upstream code is found in this module:
+    // https://github.com/openid/AppAuth-JS/blob/c30f85e490ab41c9f1e8f8ee05bfdfe964e08626/src/redirect_based_handler.ts
     Object.keys(localStorage).filter((key) => key.includes('appauth_authorization')).forEach((key) => {
       localStorage.removeItem(key);
     });


### PR DESCRIPTION
@brianhelba @dchiquito PTAL at this, I'd like to get approval of this (admittedly hacked) approach before I verify that it actually works. It's possible I've missed something, but I don't see an easy way to simply extend an existing class from upstream to patch this bug, short of wholesale forking the entirety of [this module](https://github.com/openid/AppAuth-JS/blob/master/src/redirect_based_handler.ts), which makes me uncomfortable due to the amount of code there combined with its generally poor quality.

Seeing the quality of the upstream library, combined with its apparent resistance to outside contributions, leads me to think we should spend at least a little time evaluating alternative OAuth libraries, but I don't have time for that currently.